### PR TITLE
Update sett to version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Role Variables
 
 ```
 # which version of the SETT tool to install?
-# Check available versions in https://git.dcc.sib.swiss/biwg/biomedit-transfers/-/releases
-biomedit_transfers_tool_version: 1.0.0
+# Check available versions in https://pypi.org/project/sett/
+biomedit_transfers_tool_version: 1.2.0
 
 # SETT tool will be installed in a virtualenv in this path
 biomedit_transfers_tool_venv_path: "/opt/sett"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for ansible-role-biomedit-transfers-tool
 
 # which version of the SETT tool to install?
-# Check available versions in https://git.dcc.sib.swiss/biwg/biomedit-transfers/-/releases
-biomedit_transfers_tool_version: 1.0.0
+# Check available versions in https://pypi.org/project/sett/
+biomedit_transfers_tool_version: 1.2.0
 
 # SETT tool will be installed in a virtualenv in this path
 biomedit_transfers_tool_venv_path: "/opt/sett"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,10 +33,15 @@
     virtualenv: "{{ biomedit_transfers_tool_venv_path }}"
     virtualenv_command: virtualenv-3
 
-- name: Install the BiomedIT transfer tool
+- name: Uninstall biomedit-transfers (migrated to sett)
   pip:
-    name: "biomedit-transfers=={{ biomedit_transfers_tool_version }}"
-    extra_args: --extra-index-url https://pypi.dcc.sib.swiss/
+    name: biomedit-transfers
+    state: absent
+    virtualenv: "{{ biomedit_transfers_tool_venv_path }}"
+
+- name: Install sett
+  pip:
+    name: "sett=={{ biomedit_transfers_tool_version }}"
     virtualenv: "{{ biomedit_transfers_tool_venv_path }}"
 
 - name: Add the venv binaries to PATH


### PR DESCRIPTION
Package name has been changed from biomedit-transfers to sett. The project itself has been moved from private repositories to gitlab.com and pypi.org. This PR adds a migration step and sets the default version of sett to 1.2.0 (released on 28/07/2020).