### PR TITLE
Added handling of missing /etc/sett directory.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,13 @@
       export PATH={{ biomedit_transfers_tool_venv_path }}/bin:$PATH
   when: biomedit_transfers_tool_add_to_path
 
+- name: Make sure /etc/sett exists
+    file:
+      path: /etc/sett
+      state: directory
+      mode: "0755"
+
+
 - name: Deploy a SETT config to disable version checks to pypi
   template:
     dest: /etc/sett/config.json


### PR DESCRIPTION
Deployment of SETT config to disable pypi check fails, if the /etc/sett directory does not exist.
I have added a task to create the directory.